### PR TITLE
Codec: Add libdav1d

### DIFF
--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -298,7 +298,10 @@ if ! command_exists "cargo"; then
 fi
 
 if ! command_exists "python"; then
-  echo "Python command not found. Lv2 filter and dav1d decoder will not be available."
+  echo "python command not found. Lv2 filter will not be available."
+fi
+if ! command_exists "python3"; then
+  echo "python3 command not found. dav1d decoder will not be available."
 fi
 
 ##
@@ -462,10 +465,10 @@ if build "cmake" "3.21.0"; then
   build_done "cmake" "3.21.0"
 fi
 
-if command_exists "python"; then
+if command_exists "python3"; then
   if build "dav1d" "0.9.2"; then
     # dav1d needs meson and ninja with nasm to be built
-    execute pip3 install meson ninja --quiet --no-cache-dir --disable-pip-version-check
+    execute python3 -m pip install meson ninja --quiet --no-cache-dir --disable-pip-version-check
     download "https://code.videolan.org/videolan/dav1d/-/archive/0.9.2/dav1d-0.9.2.tar.gz"
     make_dir build
     execute meson build --prefix="${WORKSPACE}" --buildtype=release --default-library=static --libdir="${WORKSPACE}"/lib

--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -294,11 +294,11 @@ if ! command_exists "curl"; then
 fi
 
 if ! command_exists "cargo"; then
-  echo "cargo not installed. rav1e will not be available."
+  echo "cargo not installed. rav1e encoder will not be available."
 fi
 
 if ! command_exists "python"; then
-  echo "Python command not found. Lv2 filter will not be available."
+  echo "Python command not found. Lv2 filter and dav1d decoder will not be available."
 fi
 
 ##
@@ -378,6 +378,20 @@ if command_exists "python"; then
   CFLAGS+=" -I$WORKSPACE/include/lilv-0"
 
   CONFIGURE_OPTIONS+=("--enable-lv2")
+
+  if build "dav1d" "0.9.2"; then
+    # dav1d needs both meson and ninja to be built
+    execute python -m pip install meson ninja --quiet --no-cache-dir --disable-pip-version-check
+    download "https://code.videolan.org/videolan/dav1d/-/archive/0.9.2/dav1d-0.9.2.tar.gz"
+    make_dir build
+    execute meson build --prefix="${WORKSPACE}" --buildtype=release --default-library=static --libdir="${WORKSPACE}"/lib
+    execute ninja -C build
+    execute ninja -C build install
+    build_done "dav1d" "0.9.2"
+  fi
+
+  CONFIGURE_OPTIONS+=("--enable-libdav1d")
+
 fi
 
 if build "yasm" "1.3.0"; then
@@ -478,7 +492,7 @@ fi
 
 if command_exists "cargo"; then
   if build "rav1e" "0.5.0-beta"; then
-    cargo install cargo-c
+    execute cargo install cargo-c
     download "https://github.com/xiph/rav1e/archive/refs/tags/v0.5.0-beta.tar.gz"
     execute cargo cinstall --prefix="${WORKSPACE}" --library-type=staticlib --crt-static --release
     build_done "rav1e" "0.5.0-beta"

--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -438,20 +438,6 @@ if build "libtool" "2.4.6"; then
   build_done "libtool" "2.4.6"
 fi
 
-if command_exists "python"; then
-  if build "dav1d" "0.9.2"; then
-    # dav1d needs meson and ninja with nasm to be built
-    execute python -m pip install meson ninja --quiet --no-cache-dir --disable-pip-version-check
-    download "https://code.videolan.org/videolan/dav1d/-/archive/0.9.2/dav1d-0.9.2.tar.gz"
-    make_dir build
-    execute meson build --prefix="${WORKSPACE}" --buildtype=release --default-library=static --libdir="${WORKSPACE}"/lib
-    execute ninja -C build
-    execute ninja -C build install
-    build_done "dav1d" "0.9.2"
-  fi
-  CONFIGURE_OPTIONS+=("--enable-libdav1d")
-fi
-
 if $NONFREE_AND_GPL; then
   if build "openssl" "1.1.1l"; then
     download "https://www.openssl.org/source/openssl-1.1.1l.tar.gz"
@@ -474,6 +460,20 @@ if build "cmake" "3.21.0"; then
   execute make -j $MJOBS
   execute make install
   build_done "cmake" "3.21.0"
+fi
+
+if command_exists "python"; then
+  if build "dav1d" "0.9.2"; then
+    # dav1d needs meson and ninja with nasm to be built
+    execute pip3 install meson ninja --quiet --no-cache-dir --disable-pip-version-check
+    download "https://code.videolan.org/videolan/dav1d/-/archive/0.9.2/dav1d-0.9.2.tar.gz"
+    make_dir build
+    execute meson build --prefix="${WORKSPACE}" --buildtype=release --default-library=static --libdir="${WORKSPACE}"/lib
+    execute ninja -C build
+    execute ninja -C build install
+    build_done "dav1d" "0.9.2"
+  fi
+  CONFIGURE_OPTIONS+=("--enable-libdav1d")
 fi
 
 if ! $MACOS_M1; then

--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -379,19 +379,6 @@ if command_exists "python"; then
 
   CONFIGURE_OPTIONS+=("--enable-lv2")
 
-  if build "dav1d" "0.9.2"; then
-    # dav1d needs both meson and ninja to be built
-    execute python -m pip install meson ninja --quiet --no-cache-dir --disable-pip-version-check
-    download "https://code.videolan.org/videolan/dav1d/-/archive/0.9.2/dav1d-0.9.2.tar.gz"
-    make_dir build
-    execute meson build --prefix="${WORKSPACE}" --buildtype=release --default-library=static --libdir="${WORKSPACE}"/lib
-    execute ninja -C build
-    execute ninja -C build install
-    build_done "dav1d" "0.9.2"
-  fi
-
-  CONFIGURE_OPTIONS+=("--enable-libdav1d")
-
 fi
 
 if build "yasm" "1.3.0"; then
@@ -449,6 +436,20 @@ if build "libtool" "2.4.6"; then
   execute make -j $MJOBS
   execute make install
   build_done "libtool" "2.4.6"
+fi
+
+if command_exists "python"; then
+  if build "dav1d" "0.9.2"; then
+    # dav1d needs meson and ninja with nasm to be built
+    execute python -m pip install meson ninja --quiet --no-cache-dir --disable-pip-version-check
+    download "https://code.videolan.org/videolan/dav1d/-/archive/0.9.2/dav1d-0.9.2.tar.gz"
+    make_dir build
+    execute meson build --prefix="${WORKSPACE}" --buildtype=release --default-library=static --libdir="${WORKSPACE}"/lib
+    execute ninja -C build
+    execute ninja -C build install
+    build_done "dav1d" "0.9.2"
+  fi
+  CONFIGURE_OPTIONS+=("--enable-libdav1d")
 fi
 
 if $NONFREE_AND_GPL; then


### PR DESCRIPTION
- libdav1d needs meson and ninja to be built, along with gcc and nasm of course
  - We can use pip package manager to install them, but python2.x is depricated.
  - So, we enforce python3 for now.